### PR TITLE
Add handling for ScirptableObject backed service

### DIFF
--- a/Runtime/Services/FlumeServiceContainer.cs
+++ b/Runtime/Services/FlumeServiceContainer.cs
@@ -39,6 +39,9 @@ namespace AIR.Flume
                 if (monoBehaviour == null)
                     monoBehaviour = gameObject.AddComponent(typeof(TImplementation));
                 _register.Register(monoBehaviour as TService);
+
+            } else if (typeof(TImplementation).IsSubclassOf(typeof(ScriptableObject))) {
+                _register.Register(ScriptableObject.CreateInstance(typeof(TImplementation)) as TService);
             } else {
                 _register.Register<TService, TImplementation>();
             }

--- a/Tests/ScriptableDependentTests.cs
+++ b/Tests/ScriptableDependentTests.cs
@@ -76,8 +76,10 @@ public class ScriptableDependentTests
         // Assert
         Assert.IsTrue(thrown);
         Application.logMessageReceived -= LogAssert();
-        Application.LogCallback LogAssert() {
-            return (condition, trace, type) => {
+        Application.LogCallback LogAssert()
+        {
+            return (condition, trace, type) =>
+            {
                 thrown =
                     type == LogType.Exception &&
                     condition.Contains(nameof(MissingDependencyException));
@@ -170,4 +172,43 @@ public class ScriptableDependentTests
     private class MockService { }
 
     private class DifferentMockService { }
+
+    [Test]
+    public void Dependent_WithSOServiceDependencies_CreatesInstanceAndInjectsDependencies()
+    {
+        // Arrange
+        _container.Register<IMockScriptableObjectService, MockScriptableObjectService>();
+
+        // Act
+        var dependent = new MockSOServiceDependent();
+
+        // Assert
+        Assert.IsTrue(dependent.InjectionCalled);
+    }
+
+    private interface IMockScriptableObjectService { }
+
+    private class MockScriptableObjectService : ScriptableObject, IMockScriptableObjectService { }
+
+    private class MockSOServiceDependent : Dependent
+    {
+        public bool InjectionCalled = false;
+
+        public void Inject(IMockScriptableObjectService mockService) =>
+            InjectionCalled = true;
+    }
+
+    [Test]
+    public void Dependent_WithPreMadeSOServiceDependencies_InjectsDependencies()
+    {
+        // Arrange
+        var SOService = ScriptableObject.CreateInstance<MockScriptableObjectService>();
+        _container.Register<IMockScriptableObjectService>(SOService);
+
+        // Act
+        var dependent = new MockSOServiceDependent();
+
+        // Assert
+        Assert.IsTrue(dependent.InjectionCalled);
+    }
 }


### PR DESCRIPTION
In line with specific handling for MonoBehaviour TImplementation, now use CreateInstance on SO.
Add Tests for SO Service, both by type and by existing instance.